### PR TITLE
Makefile: add support for PG_CONFIG environment variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,9 @@ DATA = pg_dirtyread--1.0.sql \
 
 REGRESS = extension dirtyread oid
 
-PG_CONFIG = pg_config
+ifndef PG_CONFIG
+	PG_CONFIG = pg_config
+endif
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)
 


### PR DESCRIPTION
Add Makefile support for specifying the pg_config command in an environment variable as shown in the pg_dirtyread readme with this example:

`env PG_CONFIG=/path/to/pg_config make && make install`