### PR TITLE
Travis-ci: added support for ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,10 @@ language: c
 os: linux
 dist: focal
 
+arch:
+  - AMD64
+  - ppc64le
+
 before_install:
   # travis' postgresql-common is missing apt.postgresql.org.sh (2020-05-21)
   - sudo apt-get -qq update


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing.